### PR TITLE
Adding on_delete to ForeignKey fields

### DIFF
--- a/coupons/models.py
+++ b/coupons/models.py
@@ -76,7 +76,12 @@ class Coupon(models.Model):
     valid_until = models.DateTimeField(
         _("Valid until"), blank=True, null=True,
         help_text=_("Leave empty for coupons that never expire"))
-    campaign = models.ForeignKey('Campaign', verbose_name=_("Campaign"), blank=True, null=True, related_name='coupons')
+    campaign = models.ForeignKey('Campaign',
+                                 verbose_name=_("Campaign"),
+                                 blank=True,
+                                 null=True,
+                                 related_name='coupons',
+                                 on_delete=models.CASCADE)
 
     objects = CouponManager()
 
@@ -149,8 +154,12 @@ class Campaign(models.Model):
 
 @python_2_unicode_compatible
 class CouponUser(models.Model):
-    coupon = models.ForeignKey(Coupon, related_name='users')
-    user = models.ForeignKey(user_model, verbose_name=_("User"), null=True, blank=True)
+    coupon = models.ForeignKey(Coupon, related_name='users', on_delete=models.CASCADE)
+    user = models.ForeignKey(user_model,
+                             verbose_name=_("User"),
+                             null=True,
+                             blank=True,
+                             on_delete=models.CASCADE)
     redeemed_at = models.DateTimeField(_("Redeemed at"), blank=True, null=True)
 
     class Meta:


### PR DESCRIPTION
Django 2.0 likes to complain about not having `on_delete` fields set for the models. This PR should fix that.